### PR TITLE
Added necessary import to FwData

### DIFF
--- a/itlwm/FwData.h
+++ b/itlwm/FwData.h
@@ -10,6 +10,7 @@
 #define FwData_h
 
 #include <string.h>
+#include <libkern/c++/OSContainers.h>
 
 struct FwDesc {
     const char *name;


### PR DESCRIPTION
After generation _FwBinary.cpp_ impossible to build.

`Unknown type name 'OSData'`
`Use of undeclared identifier 'OSData'`

Fixed by adding import (`libkern/c++/OSContainers.h`).

![image](https://user-images.githubusercontent.com/15520314/76838816-8153b400-6845-11ea-840e-44d8b3822e84.png)
