### PR TITLE
Fixing itlwm user client build error

### DIFF
--- a/itlwm/io.cpp
+++ b/itlwm/io.cpp
@@ -342,7 +342,7 @@ iwm_dma_contig_free(struct iwm_dma_info *dma)
     dma->buffer->release();
     dma->buffer = NULL;
     dma->vaddr = NULL;
-    dma->paddr = NULL;
+    dma->paddr = 0;
 }
 
 int itlwm::


### PR DESCRIPTION
Currently itlwm cannot be build because of a type mismatch in io.cpp. This PR fixes that so itlwm builds again and can be used with HeliPort.