### PR TITLE
Fixed getting state of connection from UserClient

### DIFF
--- a/itlwm/ItlNetworkUserClient.cpp
+++ b/itlwm/ItlNetworkUserClient.cpp
@@ -138,7 +138,7 @@ sSTATE(OSObject* target, void* data, bool isSet)
 {
     ItlNetworkUserClient *that = OSDynamicCast(ItlNetworkUserClient, target);
     struct ioctl_state *st = (struct ioctl_state *)data;
-    if (!isSet) {
+    if (isSet) {
         return kIOReturnError;
     }
     memset(st, 0, sizeof(*st));

--- a/itlwmx/ItlNetworkUserClient.cpp
+++ b/itlwmx/ItlNetworkUserClient.cpp
@@ -138,7 +138,7 @@ sSTATE(OSObject* target, void* data, bool isSet)
 {
     ItlNetworkUserClient *that = OSDynamicCast(ItlNetworkUserClient, target);
     struct ioctl_state *st = (struct ioctl_state *)data;
-    if (!isSet) {
+    if (isSet) {
         return kIOReturnError;
     }
     memset(st, 0, sizeof(*st));


### PR DESCRIPTION
Previously on HeliPort, with the latest commit that they added, https://github.com/zxystd/HeliPort/commit/413b0c4d1dc5d622da580d79509d51ccc59341a6, is now able to check the state of the connection, however I was unable to get any access to the state. Turns out that on the user client, i.e. sSTATE, would return kIOReturnError since it failed the condition for being a getter and not a setter. 

Also, when calling sPOWER, on the enable variable it seems to always be active even after calling WiFi on. Is the flag supposed to be IFF_UP or IFF_RUNNING? With IFF_RUNNING, it shows when the WiFi device is off or on. Reference: https://github.com/zxystd/itlwm/blob/086878a9642d5a3ecf34d6e82f6b84481f0b4ad7/itlwm/mac80211.cpp#L2713 